### PR TITLE
sent-dm-typescript: fix JSON escaping in publish-npm workflow_dispatch branch

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Publish to NPM
         run: |
           if [ -n "$INPUT_PATH" ]; then
-            PATHS_RELEASED="[\"$INPUT_PATH\"]"
+            PATHS_RELEASED="[\\\"$INPUT_PATH\\\"]"
           else
             PATHS_RELEASED='[\".\", \"packages/mcp-server\"]'
           fi


### PR DESCRIPTION
## Summary

- One-character escaping fix in `.github/workflows/publish-npm.yml`: the `workflow_dispatch` branch now produces the same backslash-escaped quotes the release-triggered branch already uses, so the outer `{ "paths_released": "$PATHS_RELEASED" }` argument remains valid JSON after bash expansion.
- Before this fix, manually re-running the workflow with a `path` input produced `{ "paths_released": "["packages/mcp-server"]" }` (unescaped inner quotes) and `JSON.parse` blew up at position 23 in `scripts/publish-packages.ts` before `npm publish` was ever called. Most recent occurrence: [run 25872276660](https://github.com/sentdm/sent-dm-typescript/actions/runs/25872276660).

## Why this matters now

`@sentdm/sentdm@0.27.2` shipped to npm via OIDC trusted publishing on the release-triggered run. `@sentdm/sentdm-mcp@0.27.2` failed because trusted publishing wasn't configured on the npm side yet. That's been fixed, but the workflow_dispatch path to retry the MCP publish is itself broken — this PR unblocks it. Same template-bug-workaround pattern as the PHP packagist URL, TS MCP manifest formatting, and Java byte-buddy ([sentdm/sent-dm-java#32](https://github.com/sentdm/sent-dm-java/pull/32)) fixes.

## Test plan

- [ ] After merge, run `gh workflow run publish-npm.yml --repo sentdm/sent-dm-typescript -f path=packages/mcp-server` and confirm `@sentdm/sentdm-mcp@0.27.2` lands on npm.