### PR TITLE
sent-dm-typescript: call bin/publish-npm directly after MCP removal

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,9 +33,4 @@ jobs:
 
       - name: Publish to NPM
         run: |
-          if [ -n "$INPUT_PATH" ]; then
-            PATHS_RELEASED="[\\\"$INPUT_PATH\\\"]"
-          else
-            PATHS_RELEASED='[\".\", \"packages/mcp-server\"]'
-          fi
-          pnpm tsn scripts/publish-packages.ts "{ \"paths_released\": \"$PATHS_RELEASED\" }"
+          bash bin/publish-npm


### PR DESCRIPTION
## Summary

- Replaces the dead `pnpm tsn scripts/publish-packages.ts ...` call in `.github/workflows/publish-npm.yml` with a direct `bash bin/publish-npm`.
- The 0.28.0 codegen ([PR #56](https://github.com/sentdm/sent-dm-typescript/pull/56)) deleted `scripts/publish-packages.ts` (the multi-package orchestrator, only needed when MCP was around) but left the workflow still calling it. Every release since has failed at `Error: Cannot find module './publish-packages.ts'` ([run 25873957028](https://github.com/sentdm/sent-dm-typescript/actions/runs/25873957028)).
- `bin/publish-npm` is the real OIDC/token-aware publish driver and still ships in the repo. This matches the simpler single-package workflow shape used by sibling SDKs.

## Test plan

- [ ] After merge, release-please will cut 0.28.1 (or run `gh workflow run publish-npm.yml --repo sentdm/sent-dm-typescript`). Confirm `@sentdm/sentdm@0.28.x` shows up on npm with a provenance line in the run log.